### PR TITLE
Allow separate Gson serializer and deserializer

### DIFF
--- a/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
+++ b/retrofit-converters/gson/src/main/java/retrofit2/converter/gson/GsonConverterFactory.java
@@ -47,27 +47,41 @@ public final class GsonConverterFactory extends Converter.Factory {
    * decoding from JSON (when no charset is specified by a header) will use UTF-8.
    */
   public static GsonConverterFactory create(Gson gson) {
-    return new GsonConverterFactory(gson);
+    return new GsonConverterFactory(gson, gson);
   }
 
-  private final Gson gson;
+  /**
+   * Create an instance using separate {@code gson} for serialization/deserialization conversion.
+   * Encoding to JSON and decoding from JSON (when no charset is specified by a header) will use
+   * UTF-8.
+   */
+  public static GsonConverterFactory create(Gson gsonSerializer, Gson gsonDeserializer) {
+    return new GsonConverterFactory(gsonSerializer, gsonDeserializer);
+  }
 
-  private GsonConverterFactory(Gson gson) {
-    if (gson == null) throw new NullPointerException("gson == null");
-    this.gson = gson;
+
+  private final Gson gsonSerializer;
+  private final Gson gsonDeserializer;
+
+  private GsonConverterFactory(Gson gsonSerializer, Gson gsonDeserializer) {
+    if (gsonSerializer == null || gsonDeserializer == null) {
+      throw new NullPointerException("gson == null");
+    }
+    this.gsonSerializer = gsonSerializer;
+    this.gsonDeserializer = gsonDeserializer;
   }
 
   @Override
   public Converter<ResponseBody, ?> responseBodyConverter(Type type, Annotation[] annotations,
       Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonResponseBodyConverter<>(gson, adapter);
+    TypeAdapter<?> adapter = gsonDeserializer.getAdapter(TypeToken.get(type));
+    return new GsonResponseBodyConverter<>(gsonDeserializer, adapter);
   }
 
   @Override
   public Converter<?, RequestBody> requestBodyConverter(Type type,
       Annotation[] parameterAnnotations, Annotation[] methodAnnotations, Retrofit retrofit) {
-    TypeAdapter<?> adapter = gson.getAdapter(TypeToken.get(type));
-    return new GsonRequestBodyConverter<>(gson, adapter);
+    TypeAdapter<?> adapter = gsonSerializer.getAdapter(TypeToken.get(type));
+    return new GsonRequestBodyConverter<>(gsonSerializer, adapter);
   }
 }


### PR DESCRIPTION
Some APIs require that you send them nulls in the data to represent a delete. This is something we'd want on the serializer side, but not on the deserializer side. In order to accomplish that, you need to use two separate Gson objects.